### PR TITLE
Use a powershell script to manage focus on Windows

### DIFF
--- a/FocusSublimeWindow.py
+++ b/FocusSublimeWindow.py
@@ -14,7 +14,6 @@ class FocusSublimeWindowCommand(WindowCommand):
     def run(self, **args):
         if NATIVE_FOCUS_WINDOW:
             self.window.bring_to_front()
-            return
 
         platform = sublime.platform()
         if platform == 'linux':
@@ -26,5 +25,11 @@ class FocusSublimeWindowCommand(WindowCommand):
             end tell
             """  # Brings ALL the windows forward
             subprocess.Popen(["osascript", "-e", script])
-        elif platform == 'windows':  # needs http://www.nirsoft.net/utils/nircmd.html to be installed in windows dir
-            subprocess.Popen('nircmd win activate process sublime_text.exe')
+        elif platform == 'windows':
+            startupinfo = subprocess.STARTUPINFO()
+            startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+            subprocess.Popen(
+                'powershell -Command (New-Object -ComObject WScript.Shell).AppActivate({})'
+                .format(os.getppid()),
+                startupinfo=startupinfo
+            )

--- a/README.md
+++ b/README.md
@@ -17,7 +17,4 @@ Use Sublime Text to write in your browser. Everything you type in the editor wil
 
 * An improved markdown syntax [MarkdownEditing](https://sublime.wbond.net/packages/MarkdownEditing)
 
-If you still have Sublime Text 3 then:
-
 * On Linux, [xdotool](http://www.semicomplete.com/projects/xdotool/) lets GhostText focus your Sublime Text window on a new connection.
-* On Windows, [nircmd](http://www.nirsoft.net/utils/nircmd.html) in `C:/Windows/`, lets GhostText focus your Sublime Text window on a new connection.


### PR DESCRIPTION
Fixes #4

Revert cd1a2d5 as Sublime Text's `bring_to_front` politely asks for the focus which is usually not enough when a browser has input focus.

Since we have a builtin method for MacOs in place just implement a powerscript equivalent for Windows.

Unfortunately Linux then still needs a tool ("xdotool").